### PR TITLE
Add Hermes to homepage nav and footer

### DIFF
--- a/public/images/hermes.svg
+++ b/public/images/hermes.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
+  <path d="M8 9h8"/>
+  <path d="M8 13h6"/>
+  <path d="M18 4l1.5 3L21 4"/>
+  <path d="M19 3.5V7"/>
+</svg>

--- a/src/templates/footer.html
+++ b/src/templates/footer.html
@@ -10,6 +10,9 @@
         <external-clickable-image href="https://github.com/ChidiRnweke/" id="github">
             <img src="/images/github.png" data-alt-src="/images/github-dark.png" slot="image" class="dark-toggle">
         </external-clickable-image>
+        <external-clickable-image href="https://agent.chidinweke.be">
+            <img src="/images/hermes.svg" slot="image" class="dark-toggle">
+        </external-clickable-image>
     </section>
     With ❤️ by Chidi Nweke.
 </footer>

--- a/src/templates/header.html
+++ b/src/templates/header.html
@@ -2,6 +2,7 @@
   <nav-bar>
     <a href="/">Home</a>
     <a href="/articles/">Articles</a>
+    <a href="https://agent.chidinweke.be">Hermes</a>
   </nav-bar>
 
   <dark-mode-toggle></dark-mode-toggle>


### PR DESCRIPTION
Adds Hermes to the homepage:
- **Nav bar**: New "Hermes" link pointing to `https://agent.chidinweke.be`
- **Footer**: New Hermes icon (SVG chat bubble with feather) alongside LinkedIn, Instagram, GitHub
- **Icon**: Minimalist SVG icon in `public/images/hermes.svg` — a chat/agent icon with a quill

When deployed, clients can navigate to the Hermes AI agent or spot it in the footer.